### PR TITLE
plugins/inventory/lxd.py: fix listing of containers without os / release

### DIFF
--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -666,9 +666,11 @@ class InventoryModule(BaseInventoryPlugin):
             # add network informations
             self.build_inventory_network(instance_name)
             # add os
-            self.inventory.set_variable(instance_name, 'ansible_lxd_os', self._get_data_entry('inventory/{0}/os'.format(instance_name)).lower())
+            if self._get_data_entry('inventory/{0}/os'.format(instance_name))
+                self.inventory.set_variable(instance_name, 'ansible_lxd_os', self._get_data_entry('inventory/{0}/os'.format(instance_name)).lower())
             # add release
-            self.inventory.set_variable(instance_name, 'ansible_lxd_release', self._get_data_entry('inventory/{0}/release'.format(instance_name)).lower())
+            if self._get_data_entry('inventory/{0}/release'.format(instance_name))
+                self.inventory.set_variable(instance_name, 'ansible_lxd_release', self._get_data_entry('inventory/{0}/release'.format(instance_name)).lower())
             # add profile
             self.inventory.set_variable(instance_name, 'ansible_lxd_profile', self._get_data_entry('inventory/{0}/profile'.format(instance_name)))
             # add state


### PR DESCRIPTION
In some cases, a container might be present, that was initialized empty, therefore lacking meta information about the os or the release.
Test if the data entry is None to avoid calling lower on it.